### PR TITLE
Added missing parameters type declaration to ECDH DSA sigining function.

### DIFF
--- a/src/ecdh.d.ts
+++ b/src/ecdh.d.ts
@@ -35,7 +35,7 @@ export class ECDH {
 
     ECPSVDP_DH(s: ArrayLike<number>, w: ArrayLike<number>, k: ArrayLike<number>): number;
 
-    ECPSP_DSA(shaVersion: number, rng: RNG, c: ArrayLike<number>, d: ArrayLike<number>): number;
+    ECPSP_DSA(shaVersion: number, rng: RNG, s: ArrayLike<number>, f: ArrayLike<number>, c: ArrayLike<number>, d: ArrayLike<number>): number;
 
     ECPVP_DSA(shaVersion: number, w: ArrayLike<number>, f: ArrayLike<number>, c: ArrayLike<number>, d: ArrayLike<number>): number;
 


### PR DESCRIPTION
I added missing parameters to the `ECPSP_DSA` function, namely `S` (private key) and `F` (message to sign).