### PR TITLE
Added an option to decided whether to compress a pubkey or not

### DIFF
--- a/src/ecdh.d.ts
+++ b/src/ecdh.d.ts
@@ -29,7 +29,7 @@ export class ECDH {
 
     AES_CBC_IV0_DECRYPT(k: ArrayLike<number>, c: ArrayLike<number>): number[];
 
-    KEY_PAIR_GENERATE(rng: RNG, s: ArrayLike<number>, w: ArrayLike<number>): number;
+    KEY_PAIR_GENERATE(rng: RNG, s: ArrayLike<number>, w: ArrayLike<number>, c: boolean): number;
 
     PUBLIC_KEY_VALIDATE(w: ArrayLike<number>): number;
 

--- a/src/ecdh.js
+++ b/src/ecdh.js
@@ -511,9 +511,10 @@ var ECDH = function(ctx) {
           * @parameter rng Cryptographically Secure Random Number Generator
 	  * @parameter S the private key
 	  * @parameter W the output public key, which is s.G, where G is a fixed generator
+      * @parameter C boolean indicating to compress pubkey
   	  * @return 0 or an error code
           */						
-        KEY_PAIR_GENERATE: function(RNG, S, W) {
+        KEY_PAIR_GENERATE: function(RNG, S, W, C) {
             var res = 0,
                 r, s, G, WP;
             // var T=[];
@@ -533,7 +534,7 @@ var ECDH = function(ctx) {
             s.toBytes(S);
 
             WP = G.mul(s);
-            WP.toBytes(W,false);  // To use point compression on public keys, change to true 
+            WP.toBytes(W, C);  // To use point compression on public keys, change to true 
 
             return res;
         },


### PR DESCRIPTION
Currently, if you want to compress a public key generated, you need to change it directly in the code. It's hardcoded. I simply added a parameter that would make this extensible.